### PR TITLE
Replace references to old VLSCI github.io with new URL

### DIFF
--- a/documentation_overview.md
+++ b/documentation_overview.md
@@ -15,7 +15,7 @@
 
 A GVL instance is a server, usually running as a virtual machine in a cloud environment. You can find an overview of supported clouds and how to launch an instance on the [Launch page](launch).
 
-In particular, a step-by-step guide to launching an instance on the Australian Research Cloud (NeCTAR) can be found [here](https://vlsci.github.io/lscc_docs/tutorials/gvl_launch/gvl_launch/).
+In particular, a step-by-step guide to launching an instance on the Australian Research Cloud (NeCTAR) can be found [here](http://melbournebioinformatics.github.io/MelBioInf_docs/tutorials/gvl_launch/gvl_launch/).
 
 * * *
 

--- a/get.md
+++ b/get.md
@@ -48,7 +48,7 @@ You can launch a new server instance on a public cloud, such as NeCTAR/OpenStack
 
 Use the [launch page](http://launch.genome.edu.au) to launch your own private server on the cloud, with the GVL pre-installed. You can launch a new server instance on an existing cloud, such as NeCTAR/OpenStack or Amazon/EC2 (the default for most users).
 
-Instructions on how to launch an instance can be found [here](http://vlsci.github.io/lscc_docs/tutorials/gvl_launch/gvl_launch/).
+Instructions on how to launch an instance can be found [here](http://melbournebioinformatics.github.io/MelBioInf_docs/tutorials/gvl_launch/gvl_launch/).
 
 <a id="gvl-launch-button" href="http://launch.genome.edu.au">Launch</a>
 

--- a/use.md
+++ b/use.md
@@ -17,7 +17,7 @@ hr {
 ## Personal GVL
 
 If you want to launch your own GVL please go to the [launch your own GVL](/get) page.  
-Instructions for launching a GVL instance are available [here](https://vlsci.github.io/lscc_docs/tutorials/gvl_launch/gvl_launch/).
+Instructions for launching a GVL instance are available [here](https://melbournebioinformatics.github.io/MelBioInf_docs/tutorials/gvl_launch/gvl_launch/).
 
 * * *
 
@@ -28,7 +28,7 @@ Instructions for launching a GVL instance are available [here](https://vlsci.git
 | ![GVL Logo](https://genome.edu.au/wp-content/uploads/2016/10/gvl-copy_3.jpg "Genomics Virtual Laboratory") | [Galaxy in Melbourne](http://galaxy-mel.genome.edu.au/) is available for research use | [Documents](https://wiki.galaxyproject.org/Support)  | [Support](mailto:help@genome.edu.au) |
 | ![GVL Logo](https://genome.edu.au/wp-content/uploads/2016/10/gvl-copy_3.jpg "Genomics Virtual Laboratory") | [Galaxy in Queensland](http://galaxy-qld.genome.edu.au/) is available for research use.  | [Documents](https://wiki.galaxyproject.org/Support)  | [Support](mailto:help@genome.edu.au) |
 | ![GVL Logo](https://genome.edu.au/wp-content/uploads/2016/10/gvl-copy_3.jpg "Genomics Virtual Laboratory") | [Galaxy-Tut](http://galaxy-tut.genome.edu.au) is available for teaching/learning.  | [Documents](https://wiki.galaxyproject.org/Support)  | [Support](mailto:help@genome.edu.au) |
-| ![GenomeSpace Logo](https://genome.edu.au/wp-content/uploads/2016/03/logo_genomespace.png)| [GenomeSpace Australia](https://genomespace.genome.edu.au) is available for research use.  | [Documents](https://vlsci.github.io/lscc_docs/tutorials/genomespace/genomespace/)  | [Support](mailto:help@genome.edu.au) |
+| ![GenomeSpace Logo](https://genome.edu.au/wp-content/uploads/2016/03/logo_genomespace.png)| [GenomeSpace Australia](https://genomespace.genome.edu.au) is available for research use.  | [Documents](https://melbournebioinformatics.github.io/MelBioInf_docs/tutorials/genomespace/genomespace/)  | [Support](mailto:help@genome.edu.au) |
 | ![RStudio Logo](https://genome.edu.au/wp-content/uploads/2016/03/rstudio.png) | [RStudio](http://gvl-rstudio.genome.edu.au/rstudio) in Queensland is available for research use.  |   | [Support](mailto:help@genome.edu.au) |
 
 


### PR DESCRIPTION
Still some missing links. I grepped it, I think these are the last.